### PR TITLE
feat(pull-request): add token input for PR identity

### DIFF
--- a/pull-request/action.yml
+++ b/pull-request/action.yml
@@ -1,6 +1,10 @@
 name: Create pull request
 
 inputs:
+  token:
+    description: Token used to create the pull request and push the release branch. Defaults to the workflow GITHUB_TOKEN (opens PRs as github-actions[bot]).
+    required: false
+    default: ${{ github.token }}
   next-version:
     required: true
   notes:
@@ -33,6 +37,7 @@ runs:
 
     - uses: peter-evans/create-pull-request@v6
       with:
+        token: ${{ inputs.token }}
         title: Release ${{ inputs.next-version }}
         body: |
           ## Release [${{ inputs.next-version }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.previous-version }}...${{ steps.commit.outputs.short }})


### PR DESCRIPTION
## Summary

Add an optional `token` input to the `pull-request` composite action so consumers can control which identity opens the release PR. Defaults to `github.token`, preserving current behavior (PRs open as `github-actions[bot]`).

## Why

Release PRs in consuming repos (api, centrifugo, heartbeat) should be attributable to a dedicated bot account (`thescorbot`) rather than a personal/former-employee account or the generic Actions bot. With this input, a consumer passes `token: ${{ secrets.SCORBOT_TOKEN || github.token }}` and the PR opens as thescorbot.

## Rollout note

`v1` is the rolling release **branch** (not a tag) that consumers pin via `@v1`, so merging this propagates to all consumers immediately — no tag move required.

Part of SB-3749. Consumer change: scorbit-io/api#3443.