### PR TITLE
chore(deps): bump peter-evans/create-pull-request v6 -> v7

### DIFF
--- a/pull-request/action.yml
+++ b/pull-request/action.yml
@@ -35,7 +35,7 @@ runs:
     - id: commit
       uses: pr-mpt/actions-commit-hash@v3
 
-    - uses: peter-evans/create-pull-request@v6
+    - uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ inputs.token }}
         title: Release ${{ inputs.next-version }}


### PR DESCRIPTION
Bumps `peter-evans/create-pull-request` v6 → v7 in the `pull-request` action.

Supersedes Dependabot #4, which was opened in Sep 2024 and now conflicts with #6 (token input). Our inputs (`token`, `title`, `body`, `author`, `branch`, `committer`, `commit-message`, `delete-branch`) are unchanged in v7. Validated live by the heartbeat release run (SB-3750 bootstrap) immediately after merge.