### PR TITLE
fix(slack): skip SVG images to avoid invalid_blocks

### DIFF
--- a/slack-message/build_message.py
+++ b/slack-message/build_message.py
@@ -133,7 +133,10 @@ def get_images(release):
             continue
 
         for text, url in find_images(pull["body"] or ""):
-            if "badge" in url:
+            # Skip badges and SVGs. Slack image blocks cannot render SVG, so
+            # including one (e.g. CI-bot promo images injected into PR bodies)
+            # makes Slack reject the whole message with invalid_blocks.
+            if "badge" in url or url.lower().split("?")[0].endswith(".svg"):
                 continue
 
             if url.startswith(GITHUB_USER_ATTACHMENTS_URL):


### PR DESCRIPTION
Slack image blocks can't render SVG. CI bots (Blacksmith "Codesmith") inject SVG promo images into PR bodies; `get_images` turned them into image blocks, so Slack rejected the entire deploy/release notification as `invalid_blocks` (seen on api stage-deploy after #3425). The existing `"badge" in url` filter doesn't match these. Now also skip any `.svg` (query-string aware). Real PNG/JPG screenshots from user-attachments are unaffected. Fixes notifications across api, centrifugo, heartbeat (rolling v1).